### PR TITLE
fixed jump table offset

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -218,12 +218,13 @@ parser.processMacro = (
             throw new Error(`expected to find ${tableInstance.label} in ${JSON.stringify(tableOffsets)}`);
         }
         const { offset } = tableInstance;
-        if (bytecode.slice((offset * 2) + 2, (offset * 2) + 6) !== 'xxxx') {
-            throw new Error(`expected ${tableInstance.offset} to be xxxx`);
+        const placeholder = bytecode.slice((offset * 2) + 2, (offset * 2) + 6);
+        if (placeholder !== 'xxxx') {
+            throw new Error(`expected ${placeholder} to be xxxx at offset ${tableInstance.offset}`);
         }
         const pre = bytecode.slice(0, (offset * 2) + 2);
         const post = bytecode.slice((offset * 2) + 6);
-        bytecode = `${pre}${formatEvenBytes(toHex(tableOffsets[tableInstance.label]))}${post}`;
+        bytecode = `${pre}${padNBytes(formatEvenBytes(toHex(tableOffsets[tableInstance.label])), 2)}${post}`;
     });
     return {
         ...result,


### PR DESCRIPTION
Jump table offsets are assumed to be 2 bytes, but this is not enforced in the parser. As a result, smaller offsets are broken because when you read the jump location you also end up pushing some bytecode.

To test this, run the example jump table code
```
#define jumptable JUMP_TABLE {
    lsb_0 lsb_1 lsb_2 lsb_3 lsb_3 lsb_4
}

#define macro EXAMPLE = takes(0) returns(0) {
    0x01
    __tablesize(JUMP_TABLE) __tablestart(JUMP_TABLE) 0x00 codecopy

    lsb_0:
        0x01 add stop
    lsb_1:
        0x32 add stop
    lsb_2:
        0x03 add stop
    lsb_3:
        0x04 add stop
    lsb_4:
        0x05 add stop
}
```
with
```
const main = new Runtime('example.huff', 'test');
const { stack } = await main('EXAMPLE', [], [], [{ index: 0, value: "01" }], 0);
console.log('output stack state = ', stack);
```
With the current code, the final stack is `[ <BN: 1>, <BN: c0>, <BN: 2360> ]`
With this change, the stack is the expected `[ <BN: 2> ]`

I also modified the error message for failures to find jump table offset placeholders, as I found the message to be extremely uninformative.